### PR TITLE
Improve onboarding guidance for local capture and Docker readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The script will:
 4. Start the Headphone Party control server on <http://localhost:4173>.
 
 > Need to use an existing MediaMTX instance? Run `./start.ps1 -SkipDocker` to keep Docker untouched.
+>
+> ⚠️ **Docker Desktop must be running** before you launch the script, otherwise MediaMTX cannot start and OBS/WHIP publishing
+> will fail.
 
 ### macOS / Linux (Bash or compatible shell)
 
@@ -61,7 +64,7 @@ Replace the IP with whichever interface you want to use; the Host UI also lets y
 ## Streaming workflow
 
 1. **Spin everything up** using one of the start scripts above.
-2. Open <http://localhost:4173/host> on the DJ computer. You should see:
+2. Open <http://localhost:4173/host> on the DJ computer (browsers only expose microphones on `localhost` or HTTPS). You should see:
    - Broadcast controls for MediaMTX.
    - A BPM tap panel and broadcast button.
    - Helpful tips and the local join URLs detected from your network interfaces.
@@ -104,6 +107,7 @@ Replace the IP with whichever interface you want to use; the Host UI also lets y
 
 | Symptom | Fix |
 | --- | --- |
+| Host page does not offer microphone capture | Open the host UI from <http://localhost:4173/host> or an HTTPS URL. Browsers block microphones on plain HTTP LAN addresses. |
 | Browser prompts for microphone but you hear nothing | Ensure the browser tab stays focused during capture, and confirm your virtual cable is set as the default input. |
 | Guests get "connection failed" | Check that MediaMTX is running and reachable on port 8889. The guest page shows the configured WHEP URL – adjust it if you host MediaMTX elsewhere. |
 | Audio drifts out of sync after a few songs | Have the DJ re-tap BPM and broadcast the new value, then guests hit **Align to Beat** again. |

--- a/frontend/src/components/HostView.tsx
+++ b/frontend/src/components/HostView.tsx
@@ -39,6 +39,13 @@ export default function HostView({ info, state, onBroadcast, onClear }: HostView
   const [captureMode, setCaptureMode] = useState<'microphone' | 'system'>('microphone');
   const [localBpm, setLocalBpm] = useState<number | null>(null);
   const tapsRef = useRef<number[]>([]);
+  const insecureCaptureWarning = useMemo(() => {
+    const hostname = window.location.hostname;
+    if (window.isSecureContext) {
+      return false;
+    }
+    return !['localhost', '127.0.0.1', '[::1]'].includes(hostname);
+  }, []);
 
   const whipUrl = useMemo(() => buildWhipUrl(mediamtxUrl, streamName), [mediamtxUrl, streamName]);
   const whepUrl = useMemo(() => buildWhepUrl(mediamtxUrl, streamName), [mediamtxUrl, streamName]);
@@ -216,6 +223,17 @@ export default function HostView({ info, state, onBroadcast, onClear }: HostView
         Stream name: <strong>{streamName}</strong> · Guests join at{' '}
         <strong>{localAddresses || 'detecting…'}</strong>
       </p>
+
+      {insecureCaptureWarning && (
+        <div className="panel alert">
+          <h3>Enable microphone capture</h3>
+          <p>
+            Browsers only expose microphones from a secure context. Open this page from{' '}
+            <code>http://localhost:4173/host</code> (or an HTTPS URL) on the DJ computer and share the LAN
+            links with guests separately.
+          </p>
+        </div>
+      )}
 
       <div className="panel" style={{ marginTop: '1rem' }}>
         <h3>1. Broadcast audio to MediaMTX</h3>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -53,6 +53,18 @@ button {
   box-shadow: 0 15px 45px rgba(8, 12, 24, 0.35);
 }
 
+.panel.alert {
+  background: rgba(255, 195, 40, 0.12);
+  border-color: rgba(255, 206, 86, 0.6);
+  color: #ffe4a3;
+}
+
+.panel.alert code {
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.4rem;
+}
+
 .panel h2 {
   margin-top: 0;
   font-size: 1.25rem;

--- a/start.ps1
+++ b/start.ps1
@@ -17,8 +17,17 @@ if (-not $SkipDocker) {
   if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     Write-Error "Docker is required to run MediaMTX. Install Docker Desktop and try again, or re-run with -SkipDocker."
   }
+  try {
+    docker info | Out-Null
+  } catch {
+    Write-Error "Docker Desktop is installed but not running. Start Docker Desktop and try again, or re-run with -SkipDocker."
+  }
   Write-Host "Starting MediaMTX (Docker profile: streaming)..."
-  docker compose --profile streaming up -d | Out-Null
+  try {
+    docker compose --profile streaming up -d | Out-Null
+  } catch {
+    Write-Error "Failed to start MediaMTX via Docker. Ensure Docker Desktop is running, or re-run with -SkipDocker."
+  }
 } else {
   Write-Host "Skipping MediaMTX startup (-SkipDocker requested)."
 }
@@ -33,11 +42,21 @@ if (-not $lanIp) {
 Write-Host ""
 Write-Host "Headphone Party endpoints"
 Write-Host "--------------------------"
-Write-Host ("Host control room:   http://{0}:4173/host" -f $lanIp)
-Write-Host ("Guest QR page:       http://{0}:4173/qr" -f $lanIp)
-Write-Host ("Browser WHIP ingest: http://{0}:8889/whip/party" -f $lanIp)
-Write-Host ("Guest WHEP pull:     http://{0}:8889/whep/party" -f $lanIp)
-Write-Host ("OBS RTMP server:     rtmp://{0}:1935/live (stream key: party)" -f $lanIp)
+Write-Host "Local machine (use this for microphone capture):"
+Write-Host "  Host control room:   http://localhost:4173/host"
+Write-Host "  Guest QR page:       http://localhost:4173/qr"
+Write-Host "  Browser WHIP ingest: http://localhost:8889/whip/party"
+Write-Host "  Guest WHEP pull:     http://localhost:8889/whep/party"
+Write-Host "  OBS RTMP server:     rtmp://localhost:1935/live (stream key: party)"
+if ($lanIp -and $lanIp -ne 'localhost' -and $lanIp -ne '127.0.0.1') {
+  Write-Host ""
+  Write-Host "LAN share (give this to guests on your network):"
+  Write-Host ("  Host control room:   http://{0}:4173/host" -f $lanIp)
+  Write-Host ("  Guest QR page:       http://{0}:4173/qr" -f $lanIp)
+  Write-Host ("  Browser WHIP ingest: http://{0}:8889/whip/party" -f $lanIp)
+  Write-Host ("  Guest WHEP pull:     http://{0}:8889/whep/party" -f $lanIp)
+  Write-Host ("  OBS RTMP server:     rtmp://{0}:1935/live (stream key: party)" -f $lanIp)
+}
 Write-Host ""
 Write-Host "Starting Headphone Party server on http://0.0.0.0:4173"
 npm start


### PR DESCRIPTION
## Summary
- add runtime checks to `start.ps1` so Docker Desktop must be running and surface localhost vs. LAN endpoints separately
- show an in-app warning when the host page is opened from an insecure context so users switch to localhost/HTTPS for microphone capture
- document the Docker Desktop prerequisite and localhost capture requirement in the README and add alert styling for the new hint panel

## Testing
- npm run build *(fails: `vite` CLI missing before dependencies are installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b3f506e0832ba136b6507113c2e8