### PR TITLE
Add tiny img2img sanity example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ frontend/dist/
 .DS_Store
 npm-debug.log*
 .env
+streamdiffusion_windows/.venv/
+streamdiffusion_windows/models/
+streamdiffusion_windows/outputs/

--- a/streamdiffusion_windows/README.md
+++ b/streamdiffusion_windows/README.md
@@ -1,0 +1,89 @@
+# StreamDiffusion for Windows 11 (Self contained)
+
+This folder contains a Windows-first, reproducible setup for trying Stream Diffusion style text-to-image streaming locally. Everything is pinned to specific versions and wrapped in PowerShell helpers so you can clone the repo, run one script, and then try the demos without hunting for dependencies.
+
+## What you get
+- Windows 11 friendly PowerShell automation to create a virtual environment and install pinned dependencies.
+- Optional CUDA wheel installation for PyTorch (CPU-only is supported too).
+- A tiny implementation of a streaming text-to-image loop built on top of Hugging Face Diffusers.
+- Example script to render multiple frames as a simple “stream” and save them to disk (plus an optional video/gif).
+- A Hugging Face Hub downloader so you can prefetch models before running demos.
+
+## Prerequisites (Windows 11)
+- Python 3.10 or 3.11 on PATH (64-bit). Python 3.12 is not recommended for PyTorch right now.
+- Git for Windows.
+- PowerShell 7+ (or Windows PowerShell with execution policy allowed for local scripts).
+- For GPU acceleration: recent NVIDIA drivers and the matching CUDA-enabled PyTorch wheel (the script can pull the cu121 wheel for Ampere+ GPUs).
+- (Optional) A Hugging Face token in the `HF_TOKEN` environment variable if you need gated models.
+
+## Quickstart
+1. Open **PowerShell** in the repository root and switch to this folder:
+   ```pwsh
+   cd streamdiffusion_windows
+   ```
+2. If PowerShell script execution is restricted, temporarily relax it for the session:
+   ```pwsh
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+   ```
+3. Create the virtual environment and install dependencies. Add `-UseCPU` to avoid installing the CUDA wheel.
+   ```pwsh
+   # GPU-friendly (uses cu121 by default)
+   ./setup.ps1
+   
+   # CPU-only
+   ./setup.ps1 -UseCPU
+   ```
+4. (Optional) Pre-download the model weights (defaults to `runwayml/stable-diffusion-v1-5`) so the first run is offline:
+   ```pwsh
+   ./run_demo.ps1 -DownloadOnly
+   ```
+5. Run the demo stream generator:
+   ```pwsh
+   ./run_demo.ps1 -Prompt "a tiny robot painting at a desk" -Frames 6 -Steps 25
+   ```
+   Generated images land in `streamdiffusion_windows/outputs/<timestamp>` and a summary GIF/MP4 is created when `-MakeVideo` or `-MakeGif` is used.
+
+## Files
+- `setup.ps1` – builds `.venv`, installs PyTorch (CUDA or CPU) plus the pinned dependencies in `requirements.txt`.
+- `run_demo.ps1` – convenience runner for the demo and a downloader-only mode.
+- `requirements.txt` – non-PyTorch dependencies with locked versions.
+- `examples/demo_stream.py` – Python example showing a simple streaming inference loop.
+- `examples/demo_img2img.py` – tiny img2img sanity check using a CPU-friendly toy model.
+- `streamdiffusion/pipeline.py` – lightweight StreamDiffusion-style helper that wraps the diffusers pipeline and yields frames.
+- `scripts/download_models.py` – Hugging Face snapshot downloader for offline runs.
+
+### Run the img2img sanity check (CPU friendly)
+This uses a tiny diffusers checkpoint so you can quickly verify img2img works without downloading full Stable Diffusion weights:
+
+```pwsh
+python examples/demo_img2img.py --prompt "a watercolor landscape" --num-steps 4 --strength 0.75
+```
+
+Outputs land in `streamdiffusion_windows/outputs/img2img/<timestamp>` and include both the init image and the edited result.
+
+### Pinned dependency versions
+- PyTorch / torchvision / torchaudio: **2.1.2 / 0.16.2 / 2.1.2** (CUDA cu121 by default, CPU when `-UseCPU`)
+- diffusers: **0.30.2**
+- transformers: **4.41.2**
+- accelerate: **0.32.1**
+- pillow: **10.3.0**
+- imageio: **2.34.1**
+
+## Notes on models & performance
+- The default model is `runwayml/stable-diffusion-v1-5`. You can point to any compatible diffusers checkpoint with `-ModelId` in `run_demo.ps1`.
+- GPU is strongly recommended. CPU runs are possible but will be slow; reduce `-Steps` and `-Frames` if you only have CPU.
+- The demo keeps prompts, schedulers, and seeds explicit so you can tweak them easily. Latent reuse is supported via `--reuse-latents` for slightly faster multi-frame runs.
+
+## Troubleshooting
+- If PyTorch installation fails, pass `-TorchIndexUrl` to `setup.ps1` with the exact wheel source you need (e.g., cu118). Example:
+  ```pwsh
+  ./setup.ps1 -TorchIndexUrl "https://download.pytorch.org/whl/cu118"
+  ```
+- For environments without GPU or with low VRAM, try `-UseCPU` and add `-Scheduler EulerAncestralDiscreteScheduler` plus fewer steps.
+- If you hit authentication errors while downloading models, set `HF_TOKEN` before running scripts:
+  ```pwsh
+  $env:HF_TOKEN = "<your-token>"
+  ```
+
+## License
+This folder reuses only permissively licensed dependencies from the Hugging Face ecosystem. Check each dependency’s license for details.

--- a/streamdiffusion_windows/examples/demo_img2img.py
+++ b/streamdiffusion_windows/examples/demo_img2img.py
@@ -1,0 +1,78 @@
+"""Minimal img2img example for Windows-friendly StreamDiffusion setup.
+
+This script loads a tiny diffusers image-to-image pipeline, builds a simple
+init image, and saves an edited result. It is intentionally small so it can
+serve as a sanity check without downloading full Stable Diffusion weights.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+import torch
+from diffusers import AutoPipelineForImage2Image
+from PIL import Image, ImageDraw
+
+
+DEFAULT_MODEL_ID = "hf-internal-testing/tiny-stable-diffusion-torch"
+
+
+def build_init_image(width: int, height: int) -> Image.Image:
+    """Create a simple gradient + shapes init image to exercise img2img."""
+    base = Image.new("RGB", (width, height), color=(120, 120, 200))
+    draw = ImageDraw.Draw(base)
+    draw.rectangle((width // 8, height // 8, width * 7 // 8, height * 7 // 8), outline=(20, 180, 80), width=3)
+    draw.ellipse((width // 3, height // 3, width * 2 // 3, height * 2 // 3), fill=(255, 220, 120))
+    draw.text((width // 10, height // 10), "init", fill=(0, 0, 0))
+    return base
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a tiny img2img sanity check")
+    parser.add_argument("--prompt", default="a colorful painting of a robot", help="Text prompt to guide the edit")
+    parser.add_argument("--model-id", default=DEFAULT_MODEL_ID, help="Diffusers image2image pipeline id")
+    parser.add_argument("--num-steps", type=int, default=4, help="Number of inference steps (keep low for the tiny model)")
+    parser.add_argument("--strength", type=float, default=0.7, help="How much to transform the init image")
+    parser.add_argument("--guidance", type=float, default=7.0, help="Classifier-free guidance scale")
+    parser.add_argument("--height", type=int, default=128, help="Init image height")
+    parser.add_argument("--width", type=int, default=128, help="Init image width")
+    parser.add_argument(
+        "--output-dir",
+        default=Path("streamdiffusion_windows/outputs/img2img"),
+        type=Path,
+        help="Directory to save the init and result images",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = "cpu"
+    pipe = AutoPipelineForImage2Image.from_pretrained(args.model_id, torch_dtype=torch.float32)
+    pipe.to(device)
+
+    init_image = build_init_image(args.width, args.height)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_dir = Path(args.output_dir) / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    result = pipe(
+        prompt=args.prompt,
+        image=init_image,
+        strength=args.strength,
+        guidance_scale=args.guidance,
+        num_inference_steps=args.num_steps,
+    ).images[0]
+
+    init_path = output_dir / "init.png"
+    result_path = output_dir / "result.png"
+    init_image.save(init_path)
+    result.save(result_path)
+
+    print(f"Saved init image to {init_path}")
+    print(f"Saved img2img result to {result_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamdiffusion_windows/examples/demo_stream.py
+++ b/streamdiffusion_windows/examples/demo_stream.py
@@ -1,0 +1,105 @@
+"""Example script for generating a short Stream Diffusion run."""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from streamdiffusion import StreamConfig, StreamDiffusionRunner  # noqa: E402
+
+
+SCHEDULERS = {
+    "ddim": "DDIMScheduler",
+    "dpm": "DPMSolverMultistepScheduler",
+    "euler_a": "EulerAncestralDiscreteScheduler",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a StreamDiffusion-style demo")
+    parser.add_argument("--prompt", required=True, help="Positive prompt text")
+    parser.add_argument("--negative-prompt", default=None, help="Negative prompt text")
+    parser.add_argument("--frames", type=int, default=4, help="Number of frames to generate")
+    parser.add_argument("--steps", type=int, default=30, help="Denoising steps per frame")
+    parser.add_argument("--guidance", type=float, default=7.5, help="Classifier-free guidance scale")
+    parser.add_argument("--seed", type=int, default=42, help="Base random seed")
+    parser.add_argument("--model-id", default="runwayml/stable-diffusion-v1-5", help="Diffusers model id or path")
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="Device for inference")
+    parser.add_argument(
+        "--dtype",
+        default="auto",
+        choices=["auto", "fp16", "fp32"],
+        help="Torch dtype for weights",
+    )
+    parser.add_argument(
+        "--scheduler",
+        default="dpm",
+        choices=list(SCHEDULERS.keys()),
+        help="Scheduler name (mapped to Diffusers)",
+    )
+    parser.add_argument("--output", type=Path, default=ROOT / "outputs", help="Folder to save results")
+    parser.add_argument("--reuse-latents", action="store_true", help="Re-use latents between frames")
+    parser.add_argument("--seed-stride", type=int, default=1, help="Seed increment per frame")
+    parser.add_argument("--make-gif", action="store_true", help="Save an animated GIF")
+    parser.add_argument("--make-video", action="store_true", help="Save an MP4 video")
+    parser.add_argument("--height", type=int, default=None, help="Optional height override")
+    parser.add_argument("--width", type=int, default=None, help="Optional width override")
+    parser.add_argument("--offload", action="store_true", help="Enable CPU offload for low VRAM")
+    parser.add_argument("--download-only", action="store_true", help="Download weights then exit")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    torch_dtype = {
+        "auto": torch.float16 if args.device.startswith("cuda") else torch.float32,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
+    }[args.dtype]
+
+    config = StreamConfig(
+        prompt=args.prompt,
+        negative_prompt=args.negative_prompt,
+        guidance_scale=args.guidance,
+        num_inference_steps=args.steps,
+        seed=args.seed,
+        width=args.width,
+        height=args.height,
+        reuse_latents=args.reuse_latents,
+    )
+
+    output_dir = args.output / datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[setup] Using device={args.device}, model={args.model_id}, dtype={torch_dtype}")
+    runner = StreamDiffusionRunner(
+        model_id=args.model_id,
+        device=args.device,
+        torch_dtype=torch_dtype,
+        scheduler_name=SCHEDULERS[args.scheduler],
+        offload_to_cpu=args.offload,
+    )
+
+    if args.download_only:
+        print("[download] Model weights pulled down; exiting")
+        return
+
+    frames = runner.stream(
+        config=config,
+        num_frames=args.frames,
+        seed_stride=args.seed_stride,
+        callback=lambda i, _: print(f"[frame] generated {i}")
+    )
+    runner.save_stream(frames, output_dir, make_gif=args.make_gif, make_mp4=args.make_video)
+    print(f"[done] Saved frames to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamdiffusion_windows/requirements.txt
+++ b/streamdiffusion_windows/requirements.txt
@@ -1,0 +1,9 @@
+accelerate==0.32.1
+diffusers==0.30.2
+transformers==4.41.2
+safetensors==0.4.3
+pillow==10.3.0
+imageio==2.34.1
+numpy==1.26.4
+tqdm==4.66.4
+huggingface-hub==0.24.0

--- a/streamdiffusion_windows/run_demo.ps1
+++ b/streamdiffusion_windows/run_demo.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$Prompt = "a photorealistic robot painting a portrait",
+    [string]$NegativePrompt = "",
+    [int]$Frames = 4,
+    [int]$Steps = 30,
+    [double]$Guidance = 7.5,
+    [int]$Seed = 42,
+    [string]$ModelId = "runwayml/stable-diffusion-v1-5",
+    [switch]$UseCPU,
+    [switch]$ReuseLatents,
+    [int]$SeedStride = 1,
+    [string]$Scheduler = "dpm",
+    [string]$Output = "",
+    [switch]$MakeGif,
+    [switch]$MakeVideo,
+    [int]$Height,
+    [int]$Width,
+    [switch]$Offload,
+    [switch]$DownloadOnly
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$venvPython = Join-Path $root ".venv/Scripts/python.exe"
+
+if (-not (Test-Path $venvPython)) {
+    Write-Error "Virtual environment not found. Run ./setup.ps1 first."
+    exit 1
+}
+
+$device = if ($UseCPU) { "cpu" } else { "cuda" }
+
+$cmd = @(
+    $venvPython,
+    (Join-Path $root "examples/demo_stream.py"),
+    "--prompt", $Prompt,
+    "--frames", $Frames,
+    "--steps", $Steps,
+    "--guidance", $Guidance,
+    "--seed", $Seed,
+    "--model-id", $ModelId,
+    "--device", $device,
+    "--scheduler", $Scheduler
+)
+
+if ($NegativePrompt -ne "") { $cmd += @("--negative-prompt", $NegativePrompt) }
+if ($ReuseLatents) { $cmd += "--reuse-latents" }
+if ($SeedStride -ne 1) { $cmd += @("--seed-stride", $SeedStride) }
+if ($Output -ne "") { $cmd += @("--output", $Output) }
+if ($MakeGif) { $cmd += "--make-gif" }
+if ($MakeVideo) { $cmd += "--make-video" }
+if ($Height) { $cmd += @("--height", $Height) }
+if ($Width) { $cmd += @("--width", $Width) }
+if ($Offload) { $cmd += "--offload" }
+if ($DownloadOnly) { $cmd += "--download-only" }
+
+Write-Host "[run]" ($cmd -join " ")
+& $cmd[0] $cmd[1..($cmd.Count - 1)]

--- a/streamdiffusion_windows/scripts/download_models.py
+++ b/streamdiffusion_windows/scripts/download_models.py
@@ -1,0 +1,43 @@
+"""Download diffusers models for offline use."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Prefetch a diffusers model from Hugging Face")
+    parser.add_argument("--model-id", default="runwayml/stable-diffusion-v1-5", help="Model repo id")
+    parser.add_argument(
+        "--local-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "models" / "stable-diffusion",
+        help="Where to save the snapshot",
+    )
+    parser.add_argument(
+        "--revision",
+        default=None,
+        help="Optional model revision/tag",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    token = os.environ.get("HF_TOKEN")
+    path = snapshot_download(
+        repo_id=args.model_id,
+        cache_dir=args.local_dir,
+        token=token,
+        revision=args.revision,
+        local_dir=args.local_dir,
+        local_dir_use_symlinks=False,
+    )
+    print(f"Saved snapshot to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamdiffusion_windows/setup.ps1
+++ b/streamdiffusion_windows/setup.ps1
@@ -1,0 +1,34 @@
+param(
+    [switch]$UseCPU,
+    [string]$TorchIndexUrl = "",
+    [string]$PythonExe = "python"
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$venvPath = Join-Path $root ".venv"
+$python = Join-Path $venvPath "Scripts/python.exe"
+
+function Write-Step($message) {
+    Write-Host "[setup] $message"
+}
+
+Write-Step "creating virtual environment at $venvPath"
+& $PythonExe -m venv $venvPath
+
+Write-Step "upgrading pip"
+& $python -m pip install --upgrade pip
+
+if ($UseCPU) {
+    Write-Step "installing CPU-only PyTorch 2.1.2"
+    & $python -m pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cpu
+} else {
+    $torchSource = if ($TorchIndexUrl -ne "") { $TorchIndexUrl } else { "https://download.pytorch.org/whl/cu121" }
+    Write-Step "installing CUDA-enabled PyTorch 2.1.2 from $torchSource"
+    & $python -m pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --extra-index-url $torchSource
+}
+
+Write-Step "installing pinned dependencies"
+& $python -m pip install -r (Join-Path $root "requirements.txt")
+
+Write-Step "done. Activate with:`n`t$venvPath\\Scripts\\Activate.ps1"

--- a/streamdiffusion_windows/streamdiffusion/__init__.py
+++ b/streamdiffusion_windows/streamdiffusion/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal StreamDiffusion-style helpers for Windows demos."""
+
+from .pipeline import StreamConfig, StreamDiffusionRunner
+
+__all__ = ["StreamConfig", "StreamDiffusionRunner"]

--- a/streamdiffusion_windows/streamdiffusion/pipeline.py
+++ b/streamdiffusion_windows/streamdiffusion/pipeline.py
@@ -1,0 +1,146 @@
+"""
+A lightweight, Windows-friendly Stream Diffusion helper built on top of
+Hugging Face Diffusers. It keeps configuration explicit, supports latent reuse
+between frames, and exposes a generator interface for streaming output.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Generator, Iterable, Optional
+
+import torch
+from diffusers import (
+    AutoPipelineForText2Image,
+    DDIMScheduler,
+    DPMSolverMultistepScheduler,
+    EulerAncestralDiscreteScheduler,
+)
+from PIL import Image
+
+
+@dataclass
+class StreamConfig:
+    prompt: str
+    negative_prompt: Optional[str] = None
+    guidance_scale: float = 7.5
+    num_inference_steps: int = 30
+    height: Optional[int] = None
+    width: Optional[int] = None
+    seed: int = 42
+    reuse_latents: bool = True
+
+
+class StreamDiffusionRunner:
+    """Small wrapper around a Diffusers text-to-image pipeline.
+
+    The real StreamDiffusion project focuses on real-time performance. This
+    implementation favors clarity and self-contained defaults while still
+    offering a streaming-style generator API.
+    """
+
+    def __init__(
+        self,
+        model_id: str = "runwayml/stable-diffusion-v1-5",
+        device: str = "cuda",
+        torch_dtype: torch.dtype = torch.float16,
+        scheduler_name: str = "DPMSolverMultistepScheduler",
+        offload_to_cpu: bool = False,
+    ) -> None:
+        self.model_id = model_id
+        self.device = device
+        self.torch_dtype = torch_dtype
+        self.pipe = AutoPipelineForText2Image.from_pretrained(
+            model_id,
+            torch_dtype=torch_dtype,
+            use_safetensors=True,
+        )
+        self.pipe.scheduler = self._build_scheduler(scheduler_name)
+        if offload_to_cpu:
+            self.pipe.enable_model_cpu_offload()
+        else:
+            self.pipe.to(device)
+
+    def _build_scheduler(self, name: str):
+        current = self.pipe.scheduler
+        if name == "DDIMScheduler":
+            return DDIMScheduler.from_config(current.config)
+        if name == "EulerAncestralDiscreteScheduler":
+            return EulerAncestralDiscreteScheduler.from_config(current.config)
+        return DPMSolverMultistepScheduler.from_config(current.config)
+
+    def generate_frame(
+        self, config: StreamConfig, latents: Optional[torch.Tensor] = None
+    ) -> tuple[Image.Image, Optional[bool]]:
+        generator = torch.Generator(device=self.device).manual_seed(config.seed)
+        result = self.pipe(
+            prompt=config.prompt,
+            negative_prompt=config.negative_prompt,
+            guidance_scale=config.guidance_scale,
+            num_inference_steps=config.num_inference_steps,
+            height=config.height,
+            width=config.width,
+            generator=generator,
+            latents=latents,
+        )
+        detected = result.nsfw_content_detected
+        if isinstance(detected, (list, tuple)):
+            detected = detected[0] if detected else None
+        return result.images[0], detected
+
+    def stream(
+        self,
+        config: StreamConfig,
+        num_frames: int = 4,
+        seed_stride: int = 1,
+        callback: Optional[Callable[[int, Image.Image], None]] = None,
+    ) -> Generator[Image.Image, None, None]:
+        latents: Optional[torch.Tensor] = None
+        for i in range(num_frames):
+            config.seed += seed_stride if i else 0
+            image, nsfw = self.generate_frame(config, latents=latents if config.reuse_latents else None)
+            if nsfw:
+                print("[warn] NSFW content detected; image may be filtered by the model")
+            if callback:
+                callback(i, image)
+            if config.reuse_latents:
+                latents = self.pipe.prepare_latents(
+                    batch_size=1,
+                    width=image.width,
+                    height=image.height,
+                    generator=torch.Generator(device=self.device).manual_seed(config.seed + 17),
+                    dtype=self.torch_dtype,
+                    device=self.device,
+                )
+            yield image
+
+    def save_stream(
+        self,
+        frames: Iterable[Image.Image],
+        output_dir: Path,
+        make_gif: bool = False,
+        make_mp4: bool = False,
+        fps: int = 4,
+    ) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        frames = list(frames)
+        for idx, frame in enumerate(frames):
+            frame.save(output_dir / f"frame_{idx:03d}.png")
+        if make_gif:
+            try:
+                import imageio
+
+                gif_path = output_dir / "stream.gif"
+                imageio.mimsave(gif_path, frames, fps=fps)
+                print(f"Saved GIF to {gif_path}")
+            except Exception as exc:  # pragma: no cover - optional dependency path
+                print(f"[warn] Unable to build GIF: {exc}")
+        if make_mp4:
+            try:
+                import imageio
+
+                mp4_path = output_dir / "stream.mp4"
+                imageio.mimwrite(mp4_path, frames, fps=fps)
+                print(f"Saved MP4 to {mp4_path}")
+            except Exception as exc:  # pragma: no cover - optional dependency path
+                print(f"[warn] Unable to build MP4: {exc}")


### PR DESCRIPTION
## Summary
- add a CPU-friendly img2img demo script using the tiny stable diffusion checkpoint
- document how to run the img2img sanity check and where outputs are stored

## Testing
- not run (PyTorch install blocked by proxy 403)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b6de5a6e0832b9881ecf55e20de86)